### PR TITLE
Add table of contents

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,3 +1,19 @@
+# tijmenb/yard_markdown
+
+- [`Generator`](#class-yardmarkdowngenerator)
+ - [`generate`](#generategithub_repo)
+
+- [`ExampleClass`](#class-yardmarkdownexampleclass)
+ - [`initialize`](#initializesomething)
+ - [`some_instance_method`](#some_instance_methodwith_arg--)
+ - [`something_that_raises`](#something_that_raises)
+ - [`send_email`](#send_emailopts---end)
+ - [`some_deprecated_method`](#some_deprecated_method)
+
+- [`ExampleModule`](#module-yardmarkdownexamplemodule)
+ - [`method_on_module`](#method_on_module)
+
+---
 
 ## `class YardMarkdown::Generator`
 

--- a/lib/yard_markdown.rb
+++ b/lib/yard_markdown.rb
@@ -1,6 +1,7 @@
 require 'yard_markdown/version'
 require 'yard_markdown/generator'
 require 'yard_markdown/view_model'
+require 'yard_markdown/strings'
 
 module YardMarkdown
 end

--- a/lib/yard_markdown/strings.rb
+++ b/lib/yard_markdown/strings.rb
@@ -1,0 +1,15 @@
+module YardMarkdown
+  # @private
+  class Strings
+    PUNCTUATION_REGEXP = RUBY_VERSION > "1.9" ? /[^\p{Word}\- ]/u : /[^\w\- ]/
+
+    # Taken from https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb
+    # Which is what GitHub uses, according to https://gist.github.com/asabaylus/3071099
+    def self.github_anchor(str)
+      str
+        .downcase
+        .gsub(PUNCTUATION_REGEXP, '')
+        .gsub(' ', '-')
+    end
+  end
+end

--- a/lib/yard_markdown/template.erb
+++ b/lib/yard_markdown/template.erb
@@ -1,3 +1,13 @@
+# <%= github_repo %>
+
+<% public_classes_and_modules.each do |klass| %>
+- [`<%= klass.short_name %>`](#<%= klass.anchor %>)
+<% klass.public_methods.each do |meth| %> - [`<%= meth.short_name %>`](#<%= meth.anchor %>)
+<% end %>
+<% end %>
+
+---
+
 <% public_classes_and_modules.each do |klass| %>
 ## `<%= klass.name %>`
 

--- a/lib/yard_markdown/view_model.rb
+++ b/lib/yard_markdown/view_model.rb
@@ -37,6 +37,14 @@ module YardMarkdown
       "#{klass.type} #{klass}"
     end
 
+    def short_name
+      klass.name
+    end
+
+    def anchor
+      Strings.github_anchor(name)
+    end
+
     def description
       klass.base_docstring.lines.reject { |line| line.start_with?('rubocop:') }.join
     end
@@ -76,6 +84,14 @@ module YardMarkdown
       else
         '.' + meth.signature.gsub('self.', '').gsub('def ', '')
       end
+    end
+
+    def short_name
+      meth.name
+    end
+
+    def anchor
+      Strings.github_anchor(name)
     end
 
     def description

--- a/spec/documentation_spec.rb
+++ b/spec/documentation_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe YardMarkdown do
     @generated_file = File.read("docs/readme.md")
   end
 
+  describe "table of contents" do
+    it "has entries for classes" do
+      expect(@generated_file).to include('- [`Generator`](#class-yardmarkdowngenerator)')
+    end
+
+    it "has entries for methods" do
+      expect(@generated_file).to include(' - [`generate`](#generategithub_repo)')
+    end
+  end
+
   describe "classes and modules" do
     it "uses the class name as a header" do
       expect(@generated_file).to include('## `class YardMarkdown::ExampleClass`')


### PR DESCRIPTION
This uses the fact that GitHub will automatically generate anchor tags for markdown headings.

Also adds a H1 heading with the GitHub repo name.